### PR TITLE
feat: put credentials in parameter store

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,25 @@ For personal use:
    for your personal Google account with the `https://www.googleapis.com/auth/gmail.insert` and
    `https://www.googleapis.com/auth/gmail.modify` scopes. You'll can use the gear icon to provide
    your own OAuth credentials, which simplifies this process.
-6. Create two new parameters in SSM parameter store: one for the client secret and one for the refresh token.
-  * For the client secret, provision the json-encoded fields `client_id` and `client_secret`. In the example above, you'd create the
-   `/Dev/ServiceProviders/GoogleClient` parameter with a value that looks like
-   `{"client_id":"EXAMPLE.apps.googleusercontent.com","client_secret":"0cPppYgzfKdHyysI1sPpZF4N"}`.
-  * For the refresh token, provision the json-encoded field `refresh_token`. In the example above, you'd create the
-   `/Dev/TenantCredentials/Google` parameter with a value that looks like
-   `{"client_id":"EXAMPLE.apps.googleusercontent.com","client_secret":"0cPppYgzfKdHyysI1sPpZF4N"}`.
-6. Plug your new client ID into the `google_oauth` object in the module, along with the names of the SSM parameters provisioned.
-5. `terraform apply`
+6. Create two new parameters in SSM parameter store: one for the client secret and one for the
+   refresh token.
+  * For the client secret, provision the json-encoded fields `client_id` and `client_secret`. In the
+    example above, you'd create the `/Dev/ServiceProviders/GoogleClient` parameter with a value that
+    looks like
+    `{"client_id":"EXAMPLE.apps.googleusercontent.com","client_secret":"0cPppYgzfKdHyysI1sPpZF4N"}`.
+  * For the refresh token, provision the json-encoded field `refresh_token`. In the example above,
+    you'd create the `/Dev/TenantCredentials/Google` parameter with a value that looks like
+    `{"refresh_token":"Yy6VnmnpMWdj4zgyLqJ1PQ"}`.
+7. Plug the new client ID into the `google_oauth` object in the module, along with the names of the
+   SSM parameters provisioned.
+8. `terraform apply`
 
-Refresh token updates
----------------------
+Replace the `refresh_token`
+---------------------------
 
-Instead of using the OAuth Playground to get a refresh token once, which may in rare cases cease functioning, consider using `terraform-aws-oauth2-authenticator` to simplify reauthorization following the refresh token being revoked:
+Instead of using the OAuth Playground to get a refresh token once, which may in rare cases cease
+functioning, consider using `terraform-aws-oauth2-authenticator` to simplify reauthorization
+following the refresh token being revoked:
 
 ```hcl
 locals {

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,68 @@
+locals {
+  local_arn_infix = "${data.aws_region.current.name}:${local.account_id}"
+}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "function-policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.function-logs.arn}:*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObjectTagging",
+    ]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.storage.bucket}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameter",
+    ]
+    resources = [
+      for param in [
+        var.google_oauth.secret_parameter,
+        var.google_oauth.token_parameter,
+      ] :
+      "arn:aws:ssm:${local.local_arn_infix}:parameter/${trimprefix(param, "/")}"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "assume-function-policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "function-policy" {
+  name   = "${var.name}-policy"
+  policy = data.aws_iam_policy_document.function-policy.json
+}
+
+resource "aws_iam_role" "function-role" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.assume-function-policy.json
+  description        = "Allow the ${local.function_name} Lambda to read messages from S3 and mark them for later deletion."
+}
+
+resource "aws_iam_role_policy_attachment" "function" {
+  role       = aws_iam_role.function-role.name
+  policy_arn = aws_iam_policy.function-policy.arn
+}

--- a/main.py
+++ b/main.py
@@ -7,15 +7,20 @@ import time
 import boto3
 import requests
 
+region = environ.get('AWS_REGION')
+
+s3_client = boto3.client('s3', region_name=region)
+ssm_client = boto3.client('ssm', region_name=region)
+
 client_id = environ['GOOGLE_CLIENT_ID']
-client_secret = environ['GOOGLE_CLIENT_SECRET']
-refresh_token = environ['GOOGLE_REFRESH_TOKEN']
+token_parameter = environ['GOOGLE_TOKEN_PARAMETER']
+secret_parameter = environ['GOOGLE_SECRET_PARAMETER']
 
 extra_gmail_label_ids = environ['EXTRA_GMAIL_LABEL_IDS']
 base_label_ids = ['INBOX', 'UNREAD']
 label_ids = (
-    list(set(base_label_ids) | set(extra_gmail_label_ids.split(':')))
-    if extra_gmail_label_ids else base_label_ids
+    list(set(base_label_ids)
+         | set(extra_gmail_label_ids.split(':'))) if extra_gmail_label_ids else base_label_ids
 )
 
 s3_bucket = environ['S3_BUCKET']
@@ -24,36 +29,65 @@ s3_prefix = environ.get('S3_PREFIX', '')
 account_id = environ['AWS_ACCOUNT_ID']
 
 
-def memoize_with_expiry(grace_period_sec, default_valid_sec):
+def memoize_dynamic(timeout_fn):
     def inner(fn):
         expiry_mapping = {}
 
-        def get(refresh_token: str):
-            value = expiry_mapping.get(refresh_token)
+        def reset(*params):
+            if params in expiry_mapping:
+                del expiry_mapping[params]
+
+        def get(*params):
+            prior = expiry_mapping.get(params)
             now = time.monotonic()
-            if value is not None and now < value[0]:
-                return value[1]
-            value = fn(refresh_token)
-            expires_at = now + value.get('expires_in', default_valid_sec) - grace_period_sec
-            expiry_mapping[refresh_token] = expires_at, value
+            if prior is not None and now < prior[0]:
+                return prior[1]
+            value = fn(params)
+            expiry_mapping[params] = now + timeout_fn(value), value
             return value
 
+        get.reset = reset
         return get
 
     return inner
 
 
+def memoize_with_timeout(timeout_sec):
+    return memoize_dynamic(lambda _: timeout_sec)
+
+
+def memoize_with_expiry(grace_period_sec, default_valid_sec):
+    return memoize_dynamic(
+        lambda value: value.get('expires_in', default_valid_sec) - grace_period_sec
+    )
+
+
+@memoize_with_timeout(timeout_sec=60 * 60)
+def get_parameter(parameter_name: str):
+    return json.loads(
+        ssm_client.get_parameter(Name=parameter_name, WithDecryption=True)['Parameter']['Value']
+    )
+
+
 @memoize_with_expiry(grace_period_sec=5 * 60, default_valid_sec=60 * 60)
-def get_access_token(refresh_token: str):
+def get_access_token():
+    client_secret = get_parameter(secret_parameter)['client_secret']
+    refresh_token = get_parameter(token_parameter)['refresh_token']
     res = requests.post(
         'https://oauth2.googleapis.com/token',
         data=dict(
             grant_type='refresh_token',
             refresh_token=refresh_token,
             client_id=client_id,
-            client_secret=client_secret
+            client_secret=client_secret,
         )
     )
+
+    if res.status_code in {401, 403}:
+        # Reset parameters.
+        get_parameter.reset(secret_parameter)
+        get_parameter.reset(token_parameter)
+
     res.raise_for_status()
     return res.json()
 
@@ -62,10 +96,8 @@ def lambda_handler(event, context):
     message_id = event['Records'][0]['ses']['mail']['messageId']
     print(f'Received message {message_id}')
 
-    client_s3 = boto3.client('s3')
-
     object_path = s3_prefix + message_id
-    message = client_s3.get_object(
+    message = s3_client.get_object(
         Bucket=s3_bucket,
         Key=object_path,
         ExpectedBucketOwner=account_id,
@@ -82,6 +114,8 @@ def lambda_handler(event, context):
         },
         data=message,
     )
+    if res.status_code in {401, 403}:
+        get_access_token.reset()
     if not res.ok:
         raise Exception(f'[{res.status_code}] {res.text}')
     data = res.json()
@@ -95,11 +129,13 @@ def lambda_handler(event, context):
         },
         data=json.dumps(dict(addLabelIds=label_ids)),
     )
+    if res.status_code in {401, 403}:
+        get_access_token.reset()
     if not res.ok:
         raise Exception(f'[{res.status_code}] {res.text}')
     print('Updated thread labels')
 
-    client_s3.put_object_tagging(
+    s3_client.put_object_tagging(
         Bucket=s3_bucket,
         Key=object_path,
         Tagging=dict(TagSet=[dict(Key='Forwarded', Value='true')])

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ def memoize_dynamic(timeout_fn):
             now = time.monotonic()
             if prior is not None and now < prior[0]:
                 return prior[1]
-            value = fn(params)
+            value = fn(*params)
             expiry_mapping[params] = now + timeout_fn(value), value
             return value
 
@@ -103,7 +103,7 @@ def lambda_handler(event, context):
         ExpectedBucketOwner=account_id,
     )['Body'].read()
 
-    token = get_access_token(refresh_token)['access_token']
+    token = get_access_token()['access_token']
     auth = f'Bearer {token}'
     # TODO: fix deduplication
     res = requests.post(

--- a/vars.tf
+++ b/vars.tf
@@ -36,14 +36,12 @@ variable "recipients" {
   type = set(string)
 }
 
-# TODO: support externally-configured credentials
 variable "google_oauth" {
   type = object({
-    client_id     = string
-    client_secret = string
-    refresh_token = string
+    client_id        = string
+    secret_parameter = string
+    token_parameter  = string
   })
-  sensitive = true
 }
 
 variable "inbound_tls_policy" {


### PR DESCRIPTION
BREAKING CHANGE: This will no longer be compatible with the direct method of providing the `client_secret` and `refresh_token`.

First because Terraform will store both in its state file, which is generally unsafe, and second because the `refresh_token` may in rare cases need to change, and pushing new code requires far more labor than just updating a single parameter. Additionally, this simplifies the integration of an actual OAuth2 flow.