### PR TITLE
feat: various reliability and accuracy improvements

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,6 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github_lambda_upload
       - name: Upload
-        run: ./terraform-modules/lambda/update_code.py --bucket "$AWS_DEPLOY_BUCKET" --function ses_to_gmail ./
+        run: ./terraform-modules/lambda/update_code.py --bucket "$AWS_DEPLOY_BUCKET" --function forward-emails ./
         env:
           AWS_DEPLOY_BUCKET: ${{ secrets.AWS_DEPLOY_BUCKET }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+      - improve-insert
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload:
+    name: Upload new version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # TODO: restructure this as an actual action
+      - name: Checkout action
+        uses: actions/checkout@v2
+        with:
+          repository: "skeggse/terraform-modules"
+          ref: main
+          path: terraform-modules
+      - name: Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Access
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github_lambda_upload
+      - name: Upload
+        run: ./terraform-modules/lambda/update_code.py --bucket "$AWS_DEPLOY_BUCKET" --function ses_to_gmail ./
+        env:
+          AWS_DEPLOY_BUCKET: ${{ secrets.AWS_DEPLOY_BUCKET }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+      - name: Dependencies
+        run: pip install boto3
       - name: Access
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/iam.tf
+++ b/iam.tf
@@ -45,29 +45,17 @@ data "aws_iam_policy_document" "function-policy" {
   }
 }
 
-data "aws_iam_policy_document" "assume-function-policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
+module "function_role" {
+  source = "../terraform-modules/role"
+  # source = "github.com/skeggse/terraform-modules//role?ref=main"
 
-resource "aws_iam_policy" "function-policy" {
-  name   = "${var.name}-policy"
+  name = var.name
+  description        = "the ${local.function_name} Lambda to read messages from S3 and mark them for later deletion."
   policy = data.aws_iam_policy_document.function-policy.json
-}
-
-resource "aws_iam_role" "function-role" {
-  name               = var.name
-  assume_role_policy = data.aws_iam_policy_document.assume-function-policy.json
-  description        = "Allow the ${local.function_name} Lambda to read messages from S3 and mark them for later deletion."
-}
-
-resource "aws_iam_role_policy_attachment" "function" {
-  role       = aws_iam_role.function-role.name
-  policy_arn = aws_iam_policy.function-policy.arn
+  assume_role_principals = [
+    {
+      type = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    },
+  ]
 }

--- a/iam.tf
+++ b/iam.tf
@@ -19,9 +19,14 @@ data "aws_iam_policy_document" "function-policy" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:ListBucket",
       "s3:PutObjectTagging",
     ]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.storage.bucket}/*"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.storage.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.storage.bucket}/*",
+    ]
   }
 
   statement {

--- a/iam.tf
+++ b/iam.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "function-policy" {
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
-    resources = ["${aws_cloudwatch_log_group.function-logs.arn}:*"]
+    resources = ["${aws_cloudwatch_log_group.function_logs.arn}:*"]
   }
 
   statement {
@@ -46,15 +46,14 @@ data "aws_iam_policy_document" "function-policy" {
 }
 
 module "function_role" {
-  source = "../terraform-modules/role"
-  # source = "github.com/skeggse/terraform-modules//role?ref=main"
+  source = "github.com/skeggse/terraform-modules//role?ref=main"
 
-  name = var.name
-  description        = "the ${local.function_name} Lambda to read messages from S3 and mark them for later deletion."
-  policy = data.aws_iam_policy_document.function-policy.json
+  name        = var.name
+  description = "the ${local.function_name} Lambda to read messages from S3 and mark them for later deletion."
+  policy      = data.aws_iam_policy_document.function-policy.json
   assume_role_principals = [
     {
-      type = "Service"
+      type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
     },
   ]

--- a/main.py
+++ b/main.py
@@ -8,13 +8,13 @@ from email.message import Message
 from email.generator import BytesGenerator
 from email.parser import BytesParser
 from email.utils import format_datetime, parsedate_to_datetime
-from functools import cache, wraps
+from functools import cache, partial, wraps
 from inspect import getfullargspec, ismethod
 import io
 import json
 from os import environ
 import time
-from typing import Any, Callable, Iterable, Optional, ParamSpec, TypedDict, TypeVar, Union
+from typing import Any, Callable, Iterable, Optional, TypedDict, TypeVar, Union
 import weakref
 
 import boto3
@@ -52,24 +52,34 @@ T = TypeVar('T')  # pylint: disable=invalid-name
 
 
 def cachedmethod(func: T) -> T:
+    '''
+    Cache a method associated with specific objects, such that the cache is cleaned up along with
+    the object that the method is attached to. This avoids the memory leaks associated with just
+    using @cache on a regular method.
+    '''
+
     cache_dict = weakref.WeakKeyDictionary()
 
     @wraps(func)
     def method(self, *args, **kwargs):
         instance_cache = cache_dict.get(self)
         if instance_cache is None:
-            instance_cache = cache(func)
+            instance_cache = cache(partial(func, self))
             cache_dict[self] = instance_cache
-        return instance_cache(self, *args, **kwargs)
+        return instance_cache(*args, **kwargs)
 
     return method
 
 
 def cachedproperty(func):
+    '''Cache a dynamic property for a class, avoiding the potential memory leak.'''
+
     return property(cachedmethod(func))
 
 
 def args_key(args, kwargs):
+    '''Get a hashable representation of the args and kwargs from a function invocation.'''
+
     return (args, frozenset(kwargs.items()))
 
 
@@ -78,8 +88,8 @@ P = TypeVar('P')  # pylint: disable=invalid-name
 
 def memoize_with_timeout(timeout_sec: int):
     '''
-    Memoize the given function with a TTL. Attempts no cleanup, and thus will
-    leak unless used for a fixed set of parameters.
+    Memoize the given function with a TTL. Attempts no cleanup, and thus will leak unless used for a
+    fixed set of parameters.
     '''
 
     def inner(func):
@@ -102,9 +112,8 @@ def memoize_with_timeout(timeout_sec: int):
 
 def replace_param(func, args, kwargs, param, value):
     '''
-    Given a function and a set of positional and keyword arguments for that
-    function, replace or add the parameter with the given `param` name and give
-    it the given `value`.
+    Given a function and a set of positional and keyword arguments for that function, replace or add
+    the parameter with the given `param` name and give it the given `value`.
     '''
 
     if param in kwargs or not args:
@@ -133,15 +142,15 @@ def get_parameter(parameter_name: str):
 
 class MultipartRelatedEncoder(MultipartEncoder):
     '''
-    An extension to `MultipartEncoder` which enables encoding the content as
-    `multipart/related` instead of `multipart/form-data`, which includes the
-    elision of the `content-disposition` header.
+    An extension to `MultipartEncoder` which enables encoding the content as `multipart/related`
+    instead of `multipart/form-data`, which includes the elision of the `content-disposition`
+    header.
     '''
 
     def _iter_fields(self) -> Iterable[RequestField]:
         for field in super()._iter_fields():
-            # Gmail's API does not like the content-disposition header, but
-            # neither requests nor requests_toolbelt have an option to elide it.
+            # Gmail's API does not like the content-disposition header, but neither requests nor
+            # requests_toolbelt have an option to elide it.
             field.headers = {
                 h: v for h, v in field.headers.items() if h.lower() != 'content-disposition'
             }
@@ -154,8 +163,8 @@ class MultipartRelatedEncoder(MultipartEncoder):
 
 class CustomOAuth2Session(OAuth2Session):
     '''
-    An extension of `OAuth2Session` that supports pulling the refresh token from
-    another source when the token appears to be expired or otherwise invalid.
+    An extension of `OAuth2Session` that supports pulling the refresh token from another source when
+    the token appears to be expired or otherwise invalid.
     '''
 
     def __init__(
@@ -186,9 +195,9 @@ class CustomOAuth2Session(OAuth2Session):
 @cache
 def google_session() -> requests.Session:
     '''
-    Produce a multi-use Session object authenticated for the Google API. Take
-    care not to pass the access token to a non-Google API - this does not
-    carefully ensure the token is only passed to https://gmail.googleapis.com.
+    Produce a multi-use Session object authenticated for the Google API. Take care not to pass the
+    access token to a non-Google API - this does not carefully ensure the token is only passed to
+    https://gmail.googleapis.com.
     '''
 
     client_secret: str = get_parameter(secret_parameter)['client_secret']
@@ -216,14 +225,16 @@ def google_session() -> requests.Session:
 
 
 class GmailHeader(TypedDict):
+    '''A single Gmail message header pair.'''
+
     name: str
     value: str
 
 
 class GmailMessage:
     '''
-    Represents a single message object in Gmail, and populates its fields from
-    the API. Only provides metadata.
+    Represents a single message object in Gmail, and populates its fields from the API. Only
+    provides metadata.
     '''
 
     def __init__(self, message_id: str, thread_id: Optional[str] = None):
@@ -232,6 +243,9 @@ class GmailMessage:
 
     @cachedproperty
     def metadata(self) -> dict[str, Any]:
+        '''
+        Fetch (and cache) the message's metadata.
+        '''
         with google_session() as sess:
             res = sess.get(
                 f'https://gmail.googleapis.com/gmail/v1/users/me/messages/{self.message_id}',
@@ -239,28 +253,34 @@ class GmailMessage:
                     format='metadata',
                     metadataHeaders=['internalDate', 'message-id', 'x-ses-receipt'],
                 ),
+                timeout=10,
             )
             res.raise_for_status()
             return res.json()
 
     @property
     def thread_id(self) -> str:
+        '''The (cached) thread ID.'''
         return self._thread_id or self.metadata['threadId']
 
     @property
     def history_id(self) -> str:
+        '''The (cached) history ID.'''
         return self.metadata['historyId']
 
     @property
     def rfc822_message_id(self) -> str:
+        '''The (cached) rfc822 Message-ID.'''
         return self['message-id']
 
     @property
     def headers(self) -> list[GmailHeader]:
+        '''The (cached) message headers.'''
         return self.metadata['payload']['headers']
 
     @property
     def internal_date(self) -> int:
+        '''The (cached) internal date timestamp, as milliseconds since the UTC UNIX epoch.'''
         return int(self.metadata['internalDate'])
 
     def api(self, action: str = '') -> str:
@@ -273,8 +293,8 @@ class GmailMessage:
 
     def __getitem__(self, header: str) -> str:
         '''
-        Get the value of the single instance of the given `header`. If there are
-        multiple such values or no such values, this will fail.
+        Get the value of the single instance of the given `header`. If there are multiple such
+        values or no such values, this will fail.
         '''
         value = self.get(header)
         if value is None:
@@ -283,9 +303,9 @@ class GmailMessage:
 
     def get(self, header: str, default: Optional[str] = None) -> Optional[str]:
         '''
-        Get the value of the single instance of the given `header`, if any. If
-        there are multiple such values, this will fail. If there are no such
-        values, this will return the `default` value.
+        Get the value of the single instance of the given `header`, if any. If there are multiple
+        such values, this will fail. If there are no such values, this will return the `default`
+        value.
         '''
         values = list(self.get_all(header))
         assert len(values) <= 1, f'got multiple headers for {header}'
@@ -302,13 +322,14 @@ class GmailMessage:
 
 def list_emails_by_rfc822_msg_id(rfc822_msg_id: str) -> Iterable[GmailMessage]:
     '''
-    Enumerate Gmail messages with the given rfc822 Message-ID header as
-    GmailMessage objects.
+    Enumerate Gmail messages with the given rfc822 Message-ID header as GmailMessage objects. Does
+    not implement pagination.
     '''
     with google_session() as sess:
         res = sess.get(
             'https://gmail.googleapis.com/gmail/v1/users/me/messages',
             params=dict(q=f'rfc822msgid:{rfc822_msg_id}'),
+            timeout=30,
         )
         res.raise_for_status()
         data = res.json()
@@ -321,22 +342,20 @@ def list_emails_by_rfc822_msg_id(rfc822_msg_id: str) -> Iterable[GmailMessage]:
             if msg_id == rfc822_msg_id:
                 yield gmsg
             else:
-                # Suggests malicious behavior. TODO: route this somewhere that
-                # alerts.
+                # Suggests malicious behavior. TODO: route this somewhere that alerts.
                 print(f'matched `{msg_id}` == `{rfc822_msg_id}` for {gmsg.message_id}')
 
 
 def deduplicate_email(rfc822_msg_id: str, ses_id: Optional[str] = None) -> int:
     '''
-    Deduplicate emails with the given rfc822 Message-ID header. Optionally
-    ensure that they all use the given X-SES-Receipt header as a further safety
-    belt.
+    Deduplicate emails with the given rfc822 Message-ID header. Optionally ensure that they all use
+    the given X-SES-Receipt header as a further safety belt.
     '''
     messages = list(list_emails_by_rfc822_msg_id(rfc822_msg_id))
-    all_ses_ids = {ses_id} if ses_id is not None else set()
-    assert (
-        len(all_ses_ids | {m['x-ses-receipt'] for m in messages}) == 1
-    ), 'Multiple SES receipts for the same rfc822 message ID'
+    all_ses_ids = {m['x-ses-receipt'] for m in messages}
+    if ses_id is not None:
+        all_ses_ids.add(ses_id)
+    assert len(all_ses_ids) == 1, 'Multiple SES receipts for the same rfc822 message ID'
     if 1 < len(messages) <= 3:
         kept_message = min(messages, key=lambda m: (m.internal_date, m.history_id, m.message_id))
         with google_session() as sess:
@@ -344,7 +363,7 @@ def deduplicate_email(rfc822_msg_id: str, ses_id: Optional[str] = None) -> int:
                 if message_to_remove is kept_message:
                     continue
                 assert message_to_remove.message_id != kept_message.message_id
-                sess.post(message_to_remove.api('/trash'))
+                sess.post(message_to_remove.api('/trash'), timeout=10)
         print(f'Kept {kept_message.message_id} for {rfc822_msg_id}')
     return len(messages)
 
@@ -356,10 +375,9 @@ assert callable(getattr(BytesGenerator, '_write', None)) and callable(
 
 class RawBytesGenerator(BytesGenerator):
     '''
-    Generate a valid rfc822-encoded message that was decoded using the
-    headersonly=True parameter using `email.parser`. This ensures we don't
-    change the line-ending style and don't attempt to re-encode the bytes
-    themselves.
+    Generate a valid rfc822-encoded message that was decoded using the headersonly=True parameter
+    using `email.parser`. This ensures we don't change the line-ending style and don't attempt to
+    re-encode the bytes themselves.
     '''
 
     def _write(self, msg: Message) -> None:
@@ -370,8 +388,7 @@ class RawBytesGenerator(BytesGenerator):
     @staticmethod
     def convert_bytes(msg: Message, linesep: str = '\r\n') -> bytes:
         '''
-        Serialize the given message into a buffer, and return the corresponding
-        `bytes`.
+        Serialize the given message into a buffer, and return the corresponding `bytes`.
         '''
         bytes_io = io.BytesIO()
         RawBytesGenerator(
@@ -381,9 +398,8 @@ class RawBytesGenerator(BytesGenerator):
 
 
 def infer_linesep(data: bytes, default: str = '\n') -> str:
-    r'''
-    Infer the line separator from the given data. Defaults to `'\n'` if the data
-    contains no line separator.
+    r'''Infer the line separator from the given data. Defaults to `'\n'` if the data contains no
+    line separator.
     '''
     try:
         idx = data.index(b'\n')
@@ -409,6 +425,8 @@ def get_object_tag(*, bucket: str = s3_bucket, key: str, tag: str) -> Optional[s
 
 
 class S3Object(TypedDict, total=False):
+    '''The response from a get_object S3 API call.'''
+
     AcceptRanges: str
     Body: StreamingBody
     ContentLength: int
@@ -422,14 +440,37 @@ class S3Object(TypedDict, total=False):
 
 
 class SESMessage:
-    # obj: dict[str, Any]
+    '''
+    A representation of an SES message that's been delivered to S3, along with some parsed metadata.
+    '''
 
     def __init__(self, bucket: str, key: str):
         self.bucket = bucket
         self.key = key
+        self._buffer = None
+
+    @property
+    def buffer(self) -> bytes:
+        '''
+        Get the current message buffer, which may or may not have been modified from the S3
+        representation to support clarifications.
+        '''
+        return self._buffer if self._buffer is not None else bytes(self)
+
+    @buffer.setter
+    def buffer(self, value: bytes) -> None:
+        '''
+        Set the SES message's buffer, to support modifying the buffer with clarifications -
+        particularly as a result of delayed delivery.
+        '''
+        self._buffer = value
 
     @cachedproperty
     def obj(self) -> S3Object:
+        '''
+        The (cached) object representation from S3, including a cached body. Prefer bytes(self) to
+        get access to the body content, as this stream is only provided once and may be consumed.
+        '''
         return s3_client.get_object(
             Bucket=self.bucket, Key=self.key, ExpectedBucketOwner=account_id
         )
@@ -440,17 +481,25 @@ class SESMessage:
 
     @cachedmethod
     def email_message(self) -> Message:
-        return BytesParser().parsebytes(bytes(self))
+        '''
+        The (cached) parsed `email.message.Message` object from the raw object content. Only
+        includes parsed headers, and does not include a parsed representation of the body. The
+        body's raw encoded content is available through the Message's `get_payload` method.
+        '''
+        return BytesParser().parsebytes(bytes(self), headersonly=True)
 
     @property
     def rfc822_message_id(self) -> str:
+        '''The message's (cached) rfc822 Message-ID header'''
         return self.email_message()['message-id']
 
     @cachedmethod
     def was_forwarded(self) -> bool:
+        '''Check whether the message has already been marked as forwarded. Cached.'''
         return get_object_tag(bucket=self.bucket, key=self.key, tag='Forwarded') == 'true'
 
     def set_forwarded(self, value: bool) -> None:
+        '''Mark the message's S3 object as forwarded.'''
         s3_client.put_object_tagging(
             Bucket=self.bucket,
             Key=self.key,
@@ -459,14 +508,25 @@ class SESMessage:
 
     @property
     def body(self) -> StreamingBody:
+        '''
+        The cached StreamingBody, which may have already been consumed. Prefer bytes(self).
+        '''
         return self.obj['Body']
 
     @property
     def last_modified(self) -> datetime:
+        '''
+        The datetime that the object was last modified, corresponding to the point in time that SES
+        received the message and inserted it into S3.
+        '''
         return self.obj['LastModified']
 
 
-def insert_message(ses_msg: SESMessage, metadata: dict[str, Any], content: bytes) -> None:
+def insert_message(ses_msg: SESMessage, metadata: dict[str, Any]) -> None:
+    '''
+    Insert the given SES message into Gmail with the given metadata and modified content.
+    '''
+
     with google_session() as sess:
         # TODO: handle message threading
         # TODO: can we get eventbridge to tell us if this is a possible event
@@ -474,7 +534,7 @@ def insert_message(ses_msg: SESMessage, metadata: dict[str, Any], content: bytes
         encoder = MultipartRelatedEncoder(
             fields=[
                 (None, (None, json.dumps(metadata), 'application/json')),
-                (None, (None, content, 'message/rfc822')),
+                (None, (None, ses_msg.buffer, 'message/rfc822')),
             ]
         )
         res = sess.post(
@@ -482,6 +542,7 @@ def insert_message(ses_msg: SESMessage, metadata: dict[str, Any], content: bytes
             headers={'content-type': encoder.content_type},
             data=encoder,
             params=dict(internalDateSource='dateHeader'),
+            timeout=10,
         )
         res.raise_for_status()
         data = res.json()
@@ -490,30 +551,19 @@ def insert_message(ses_msg: SESMessage, metadata: dict[str, Any], content: bytes
         ses_msg.set_forwarded(True)
         print('Marked S3 object for deletion')
 
-        matched_emails = deduplicate_email(ses_msg.rfc822_message_id)
-        if not matched_emails:
-            print(f'No messages found for rfc822 message id `{ses_msg.rfc822_message_id}`')
-        elif matched_emails > 3:
-            # TODO: this should really notify
-            print(
-                'Tried to deduplicate more than three messages for rfc822 '
-                f'message id `{ses_msg.rfc822_message_id}`!'
-            )
-
 
 def forward_email(message_id: str, proactive_duplicate_check: bool = False) -> bool:
     '''
-    Forward the email with the given SES message ID, corresponding to the S3
-    object key. Optionally verify that the email has not already been forwarded
-    when `proactive_duplicate_check=True`.
+    Forward the email with the given SES message ID, corresponding to the S3 object key. Optionally
+    verify that the email has not already been forwarded when `proactive_duplicate_check=True`.
     '''
 
     print(f'Received message {message_id}')
 
     ses_msg = SESMessage(bucket=s3_bucket, key=s3_prefix + message_id)
-
-    msg_bytes = bytes(ses_msg)
     pmsg = ses_msg.email_message()
+
+    print(f'Processing message as {ses_msg.rfc822_message_id}')
 
     # TODO: should this also check the Forwarded header?
     if proactive_duplicate_check:
@@ -548,16 +598,28 @@ def forward_email(message_id: str, proactive_duplicate_check: bool = False) -> b
         else:
             pmsg['Date'] = new_header
         # TODO: stream this instead of buffering it.
-        msg_bytes = RawBytesGenerator.convert_bytes(pmsg, linesep=infer_linesep(msg_bytes))
+        ses_msg.buffer = RawBytesGenerator.convert_bytes(
+            pmsg, linesep=infer_linesep(bytes(ses_msg))
+        )
 
-    insert_message(ses_msg=ses_msg, metadata=message_metadata, content=msg_bytes)
+    insert_message(ses_msg=ses_msg, metadata=message_metadata)
+
+    matched_copies = deduplicate_email(ses_msg.rfc822_message_id)
+    if not matched_copies:
+        print(f'No messages found for rfc822 message id `{ses_msg.rfc822_message_id}`')
+    elif matched_copies > 3:
+        # TODO: this should really notify
+        print(
+            'Tried to deduplicate more than three messages for rfc822 '
+            f'message id `{ses_msg.rfc822_message_id}`!'
+        )
     return True
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> None:  # pylint: disable=unused-argument
     '''
-    Handle the Lambda invocation, either via SES -> SNS, or via manual
-    invocation to handle operational outages/authentication failure gaps.
+    Handle the Lambda invocation, either via SES -> SNS, or via manual invocation to handle
+    operational outages/authentication failure gaps.
     '''
 
     records = event.get('Records')
@@ -568,12 +630,10 @@ def lambda_handler(event: dict[str, Any], context: Any) -> None:  # pylint: disa
         ):
             for obj in page['Contents']:
                 ses_msg = SESMessage(bucket=s3_bucket, key=obj['Key'])
-                key = obj['Key']
                 do_forward = True if event.get('ignoreTags', False) else not ses_msg.was_forwarded()
                 if do_forward:
-                    # TODO: don't re-forward deleted emails. This will only
-                    # happen if we are unsuccessful in recording the result from
-                    # Gmail's API as a Forwarded=true.
+                    # TODO: don't re-forward deleted emails. This will only happen if we are
+                    # unsuccessful in recording the result from Gmail's API as a Forwarded=true.
                     forward_email(ses_msg.key, proactive_duplicate_check=True)
     else:
         print(f'Processing {len(records)} records')

--- a/main.tf
+++ b/main.tf
@@ -38,31 +38,44 @@ data "aws_iam_policy_document" "storage-policy" {
 # Temporarily holds the (up to 30MB) raw message data.
 resource "aws_s3_bucket" "storage" {
   bucket = local.bucket_name
-  acl    = "private"
-  policy = data.aws_iam_policy_document.storage-policy.json
+}
 
-  lifecycle_rule {
-    enabled = true
-    id      = "delete-old-forwarded-emails"
-    tags = {
-      Forwarded = "true"
+resource "aws_s3_bucket_policy" "storage_policy" {
+  bucket = aws_s3_bucket.storage.bucket
+  policy = data.aws_iam_policy_document.storage-policy.json
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "storage_lifecycle" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  rule {
+    status = "Enabled"
+    id     = "delete-old-forwarded-emails"
+    filter {
+      and {
+        tags = {
+          Forwarded = "true"
+        }
+      }
     }
 
     expiration {
       days = 7
     }
   }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "storage-bpa" {
+resource "aws_s3_bucket_public_access_block" "storage_bpa" {
   bucket = aws_s3_bucket.storage.bucket
 
   block_public_acls       = true
@@ -71,7 +84,7 @@ resource "aws_s3_bucket_public_access_block" "storage-bpa" {
   restrict_public_buckets = true
 }
 
-resource "aws_cloudwatch_log_group" "function-logs" {
+resource "aws_cloudwatch_log_group" "function_logs" {
   name              = "/aws/lambda/${local.function_name}"
   retention_in_days = 90
 }
@@ -97,10 +110,9 @@ data "aws_ssm_parameter" "token" {
 }
 
 module "function" {
-  source = "../terraform-modules/lambda"
-  # source = "github.com/skeggse/terraform-modules//lambda?ref=main"
+  source = "github.com/skeggse/terraform-modules//lambda?ref=main"
 
-  name = local.function_name
+  name     = local.function_name
   role_arn = module.function_role.arn
 
   deploy_bucket = var.deploy_bucket
@@ -108,8 +120,9 @@ module "function" {
   handler = "main.lambda_handler"
   runtime = "python3.9"
 
-  timeout = 60
-  memory_size = 256
+  timeout                = 60
+  memory_size            = 256
+  logs_retention_in_days = 90
 
   env_vars = {
     AWS_ACCOUNT_ID = local.account_id
@@ -127,15 +140,20 @@ module "function" {
   }
 }
 
-resource "aws_lambda_permission" "ses-invoke" {
-  statement_id   = "allowSesInvoke"
+resource "aws_lambda_permission" "ses_invoke" {
+  statement_id_prefix   = "allowSesInvoke"
   function_name  = module.function.function_arn
+  qualifier = module.function.function_qualifier
   principal      = "ses.amazonaws.com"
   action         = "lambda:InvokeFunction"
   source_account = local.account_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-resource "aws_ses_receipt_rule" "store-and-forward" {
+resource "aws_ses_receipt_rule" "store_and_forward" {
   name          = "${var.name}-store-and-forward"
   rule_set_name = var.ses_rule_set_name
   recipients    = var.recipients
@@ -161,4 +179,8 @@ resource "aws_ses_receipt_rule" "store-and-forward" {
     # Just in case you change the name on this.
     create_before_destroy = true
   }
+
+  depends_on = [
+    aws_lambda_permission.ses_invoke,
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_lambda_function" "function" {
   handler          = "main.lambda_handler"
   # TODO: bundle the requests module before upgrading this.
   # https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/
-  runtime = "python3.7"
+  runtime = "python3.9"
 
   timeout     = 60
   memory_size = 256
@@ -114,6 +114,8 @@ resource "aws_lambda_function" "function" {
       S3_PREFIX = var.s3_bucket_prefix == null ? null : trimsuffix(var.s3_bucket_prefix, "/")
 
       EXTRA_GMAIL_LABEL_IDS = join(":", var.extra_gmail_label_ids)
+
+      PYTHONPATH = "site-packages"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ line-length = 100
 target-version = ['py310']
 skip-string-normalization = true
 
-[tool.pylint]
+[tool.pylint.'MESSAGES CONTROL']
 max-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 100
+target-version = ['py310']
+skip-string-normalization = true
+
+[tool.pylint]
+max-line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests-oauthlib==1.3.0
+requests-toolbelt==0.9.1

--- a/vars.tf
+++ b/vars.tf
@@ -2,6 +2,10 @@ variable "name" {
   type = string
 }
 
+variable "deploy_bucket" {
+  type = string
+}
+
 variable "s3_bucket_name" {
   type    = string
   default = null


### PR DESCRIPTION
Fixes #5, #8, #11 and #12:

## Combine API calls

We combine the `insert` and `modify` calls into a single `insert` call.

## Repair date header

For messages whose delivery to Gmail were delayed (perhaps due to expired credentials, or perhaps due to eventbridge delays), we should fall back on the timestamp from the S3 object, which is a reasonable balance between accurate and trustworthy.

## Deduplicate messages

To handle transient failures and redeliveries, and to improve the reliability of recover operations, we need to deduplicate inserted messages.

## Use an off-the-shelf OAuth2 client

Instead of reimplementing bits of the OAuth2 spec in Python, just use `requests-oauthlib`. It's missing a couple features, however, which we've patched around.