### PR TITLE
fix: handle test messages

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,12 +141,12 @@ module "function" {
 }
 
 resource "aws_lambda_permission" "ses_invoke" {
-  statement_id_prefix   = "allowSesInvoke"
-  function_name  = module.function.function_arn
-  qualifier = module.function.function_qualifier
-  principal      = "ses.amazonaws.com"
-  action         = "lambda:InvokeFunction"
-  source_account = local.account_id
+  statement_id_prefix = "allowSesInvoke"
+  function_name       = module.function.function_arn
+  qualifier           = module.function.function_qualifier
+  principal           = "ses.amazonaws.com"
+  action              = "lambda:InvokeFunction"
+  source_account      = local.account_id
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
When sending a test message, the received message will appear to duplicate the sent message. For testing, this isn't helpful, so skip duplicates that don't have all the extra labels.